### PR TITLE
Better german translation

### DIFF
--- a/src/strings-de.c
+++ b/src/strings-de.c
@@ -3,7 +3,7 @@
 const char* const HOURS_DE[] = {
   // AM hours
   "zwölf",
-  "ein",
+  "eins",
   "zwei",
   "drei",
   "vier",
@@ -17,7 +17,7 @@ const char* const HOURS_DE[] = {
 
   // PM hours
   "zwölf",
-  "ein",
+  "eins",
   "zwei",
   "drei",
   "vier",
@@ -43,9 +43,9 @@ const char* const RELS_DE[] = {
   "zehn nach *$1",
   "viertel nach *$1",
   "zwanzig nach *$1",
-  "fünfund- zwanzig nach *$1",
+  "fünf vor halb *$2",
   "halb *$2",
-  "fünfund- zwanzig vor *$2",
+  "fünf nach halb *$2",
   "zwanzig vor *$2",
   "viertel vor *$2",
   "zehn vor *$2",


### PR DESCRIPTION
Right now it's "ein Uhr", which works if you actually mean one o'clock, but not when it's five past one, then in German it needs to be "eins", i.e "fünf nach eins". This way, one o'clock would still be wrong, because it would be "eins uhr" instead of "ein uhr", but this way it would be wrong ten minutes each day instead of 2x55 minutes.

"fünf vor halb" and "fünf nach halb" sound more natural in German and should also avoid the other current problem, that fünfund & zwanzig are both one letter to long so they are shown as "fünfun zwanzi", which looks weird. This is still a problem with zwanzi, but that could only be changed through a smaller font.